### PR TITLE
Update utils.py

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -90,7 +90,7 @@ def extract_feature(file_name, **kwargs):
             chroma = np.mean(librosa.feature.chroma_stft(S=stft, sr=sample_rate).T,axis=0)
             result = np.hstack((result, chroma))
         if mel:
-            mel = np.mean(librosa.feature.melspectrogram(X, sr=sample_rate).T,axis=0)
+            mel = np.mean(librosa.feature.melspectrogram(y=X, sr=sample_rate).T,axis=0)
             result = np.hstack((result, mel))
         if contrast:
             contrast = np.mean(librosa.feature.spectral_contrast(S=stft, sr=sample_rate).T,axis=0)


### PR DESCRIPTION
The function librosa.feature.melspectrogram was updated and you need to specify y= for the audio time series argument or else you will get a positional error. When I added this edit on my own machine it fixed the error.